### PR TITLE
Unique positions

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,6 @@ const (
 var Required = []string{Token}
 
 var (
-	ErrEmptyConfig          = errors.New("missing or empty config")
 	ErrRequiredParamMissing = errors.New("required parameter missing")
 )
 

--- a/source_test.go
+++ b/source_test.go
@@ -17,9 +17,10 @@ package notion
 import (
 	"context"
 	"errors"
-	"github.com/matryer/is"
 	"testing"
 	"time"
+
+	"github.com/matryer/is"
 )
 
 func TestSource_Config_FailsWhenEmpty(t *testing.T) {


### PR DESCRIPTION
### Description

Conduit 0.2.1 requires positions to be unique. However, this connector uses a page's `last_edited_time` as its position, which isn't always unique, especially with `last_edited_time`'s precision being in minutes. 

Note: we will likely revert this change once we upgrade the Conduit Connector SDK to 0.3.0.

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-notion/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.