### PR TITLE
Handle rate limiting in the Notion API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/conduitio-labs/conduit-connector-notion
 go 1.19
 
 require (
-	github.com/conduitio-labs/notionapi v0.0.0-20221214123948-7eddf0d502e8
+	github.com/conduitio-labs/notionapi v0.0.0-20221214135932-7ff748e245f3
 	github.com/conduitio/conduit-connector-sdk v0.2.0
 	github.com/matryer/is v1.4.0
 	github.com/tidwall/gjson v1.14.4

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/conduitio-labs/conduit-connector-notion
 go 1.19
 
 require (
+	github.com/conduitio-labs/notionapi v0.0.0-20221214123948-7eddf0d502e8
 	github.com/conduitio/conduit-connector-sdk v0.2.0
-	github.com/jomei/notionapi v1.9.3
 	github.com/matryer/is v1.4.0
 	github.com/tidwall/gjson v1.14.4
 )

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/conduitio-labs/notionapi v0.0.0-20221214123948-7eddf0d502e8 h1:k29n71F/EMRmH8BAKvfrIam2v8gY1sf8TQDHOI0Eb1M=
-github.com/conduitio-labs/notionapi v0.0.0-20221214123948-7eddf0d502e8/go.mod h1:iHUKAxOmSyhXBlqI0PAviHqf+xBlS003Kmpz9nnoOZU=
+github.com/conduitio-labs/notionapi v0.0.0-20221214135932-7ff748e245f3 h1:t4kMcfK+O9CjzXoc3BeMqgBbQkl7/d8waJLI01pNa3g=
+github.com/conduitio-labs/notionapi v0.0.0-20221214135932-7ff748e245f3/go.mod h1:iHUKAxOmSyhXBlqI0PAviHqf+xBlS003Kmpz9nnoOZU=
 github.com/conduitio/conduit-connector-protocol v0.2.0 h1:gwYXVKEMgTtU67ephQ5WwTGIDbT/eTLA9Mdr9Bnbqxc=
 github.com/conduitio/conduit-connector-protocol v0.2.0/go.mod h1:udCU2AkLcYQoLjAO06tHVL2iFJPw+DamK+wllnj50hk=
 github.com/conduitio/conduit-connector-sdk v0.2.0 h1:yReJT3SOAGqJIlk59WC5FPgpv0Gg+NG4NFj6FJ89XnM=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/conduitio-labs/notionapi v0.0.0-20221214123948-7eddf0d502e8 h1:k29n71F/EMRmH8BAKvfrIam2v8gY1sf8TQDHOI0Eb1M=
+github.com/conduitio-labs/notionapi v0.0.0-20221214123948-7eddf0d502e8/go.mod h1:iHUKAxOmSyhXBlqI0PAviHqf+xBlS003Kmpz9nnoOZU=
 github.com/conduitio/conduit-connector-protocol v0.2.0 h1:gwYXVKEMgTtU67ephQ5WwTGIDbT/eTLA9Mdr9Bnbqxc=
 github.com/conduitio/conduit-connector-protocol v0.2.0/go.mod h1:udCU2AkLcYQoLjAO06tHVL2iFJPw+DamK+wllnj50hk=
 github.com/conduitio/conduit-connector-sdk v0.2.0 h1:yReJT3SOAGqJIlk59WC5FPgpv0Gg+NG4NFj6FJ89XnM=
@@ -70,8 +72,6 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jhump/protoreflect v1.10.2-0.20211108190630-d551e22cd340 h1:Vdzuzjwa0C0Vd7+eBTXaEKqarx2S0TG1u5TTugjHLkk=
-github.com/jomei/notionapi v1.9.3 h1:1NoHFeQGe65PYDaWMxp6iW49wROZBdxrdwDEVRH+McA=
-github.com/jomei/notionapi v1.9.3/go.mod h1:wgxFlmxL+oIfxclWkt8jta0PkcBepajish2uCxzBxTo=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=

--- a/source.go
+++ b/source.go
@@ -23,8 +23,8 @@ import (
 	"strconv"
 	"time"
 
+	notion "github.com/conduitio-labs/notionapi"
 	sdk "github.com/conduitio/conduit-connector-sdk"
-	notion "github.com/jomei/notionapi"
 )
 
 type position struct {

--- a/text_extraction.go
+++ b/text_extraction.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	notion "github.com/jomei/notionapi"
+	notion "github.com/conduitio-labs/notionapi"
 	"github.com/tidwall/gjson"
 )
 

--- a/text_extraction_test.go
+++ b/text_extraction_test.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"testing"
 
-	notion "github.com/jomei/notionapi"
+	notion "github.com/conduitio-labs/notionapi"
 	"github.com/matryer/is"
 )
 


### PR DESCRIPTION
### Description

This PR changes the connector to use https://github.com/conduitio-labs/notionapi, which is a fork of the library we currently use. Our fork adds handling for the rate limiting ([relevant PR](https://github.com/conduitio-labs/notionapi/pull/2)) which may occur in the Notion API.
Fixes #6 

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-notion/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.