### PR TITLE
Skip children of blocks with unsupported type

### DIFF
--- a/source.go
+++ b/source.go
@@ -133,7 +133,7 @@ func (s *Source) nextPage(ctx context.Context) (sdk.Record, error) {
 		Str("page_id", id).
 		Msg("fetching page")
 
-	// fetch the page and then all of its children
+	// fetch the page
 	page, err := s.client.Page.Get(ctx, notion.PageID(id))
 	if err != nil {
 		// The search endpoint that we use to list all the pages
@@ -151,7 +151,25 @@ func (s *Source) nextPage(ctx context.Context) (sdk.Record, error) {
 		return sdk.Record{}, fmt.Errorf("failed fetching page %v: %w", id, err)
 	}
 
-	children, err := s.getChildren(ctx, id)
+	// fetch the page block and then all of its children
+	pageBlock, err := s.client.Block.Get(ctx, notion.BlockID(page.ID))
+	if err != nil {
+		// The search endpoint that we use to list all the pages
+		// can return stale results.
+		// It's also possible that a page has been deleted after
+		// we got the ID but before we actually read the whole page.
+		if s.notFound(err) {
+			sdk.Logger(ctx).Info().
+				Str("block_id", id).
+				Msg("the resource does not exist or the resource has not been shared with owner of the token")
+
+			return s.nextPage(ctx)
+		}
+
+		return sdk.Record{}, fmt.Errorf("failed fetching page block %v: %w", id, err)
+	}
+
+	children, err := s.getChildren(ctx, pageBlock)
 	if err != nil {
 		return sdk.Record{}, fmt.Errorf("failed fetching content for %v: %w", id, err)
 	}
@@ -171,7 +189,12 @@ func (s *Source) nextPage(ctx context.Context) (sdk.Record, error) {
 }
 
 // getChildren gets all the child and grand-child blocks of the input block
-func (s *Source) getChildren(ctx context.Context, blockID string) ([]notion.Block, error) {
+func (s *Source) getChildren(ctx context.Context, block notion.Block) ([]notion.Block, error) {
+	if block.GetType() == notion.BlockTypeUnsupported {
+		// skip children of unsupported block types
+		return []notion.Block{}, nil
+	}
+
 	var children []notion.Block
 
 	fetch := true
@@ -179,7 +202,7 @@ func (s *Source) getChildren(ctx context.Context, blockID string) ([]notion.Bloc
 	for fetch {
 		resp, err := s.client.Block.GetChildren(
 			ctx,
-			notion.BlockID(blockID),
+			block.GetID(),
 			&notion.Pagination{
 				StartCursor: cursor,
 			},
@@ -187,7 +210,7 @@ func (s *Source) getChildren(ctx context.Context, blockID string) ([]notion.Bloc
 		if err != nil {
 			return nil, fmt.Errorf(
 				"failed getting children for block ID %v, cursor %v: %w",
-				blockID,
+				block.GetID(),
 				cursor,
 				err,
 			)
@@ -196,11 +219,14 @@ func (s *Source) getChildren(ctx context.Context, blockID string) ([]notion.Bloc
 		// get grandchildren as well
 		for _, child := range resp.Results {
 			children = append(children, child)
-			grandChildren, err := s.getChildren(ctx, child.GetID().String())
-			if err != nil {
-				return nil, err
+			// Skip children of unsupported block types
+			if child.GetType() != notion.BlockTypeUnsupported {
+				grandChildren, err := s.getChildren(ctx, child)
+				if err != nil {
+					return nil, err
+				}
+				children = append(children, grandChildren...)
 			}
-			children = append(children, grandChildren...)
 		}
 
 		fetch = resp.HasMore


### PR DESCRIPTION
### Description

Prevents the attempt to fetch children of blocks with the `unsupported` type. 
Fixes #30 

** Testing still in-progress**

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-notion/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.